### PR TITLE
disable onChange on previous next

### DIFF
--- a/docs/index.tsx
+++ b/docs/index.tsx
@@ -37,9 +37,16 @@ ReactDOM.render(
       <label htmlFor="ex-2">
         With default year and month
         <MonthPickerInput
+          inputRef={(ref) => {
+            console.log(ref)
+          }}
           year={new Date().getFullYear()}
           month={new Date().getMonth()}
-          inputProps={{id: "ex-2", name: "ex-2"}} />
+          inputProps={{id: "ex-2", name: "ex-2"}} 
+          onChange={console.log}
+          onChangeYearUpdate={false}
+        />
+          
       </label>
     </div>
   ),

--- a/docs/index.tsx
+++ b/docs/index.tsx
@@ -38,12 +38,11 @@ ReactDOM.render(
         With default year and month
         <MonthPickerInput
           inputRef={(ref) => {
-            console.log(ref)
+            this.input = ref
           }}
           year={new Date().getFullYear()}
           month={new Date().getMonth()}
           inputProps={{id: "ex-2", name: "ex-2"}} 
-          onChange={console.log}
           onChangeYearUpdate={false}
         />
           

--- a/src/MonthPickerInput.tsx
+++ b/src/MonthPickerInput.tsx
@@ -132,7 +132,12 @@ class MonthPickerInput extends Component<IProps, IState> {
       dateFormat = DATE_FORMAT["ja"];
     }
     return Object.assign({}, {
-      ref: inputRef ? inputRef : (input) => { if(input) this.input = input; },
+      ref: (input) => { 
+        if(input) 
+          this.input = input; 
+        
+        inputRef && inputRef(input) 
+      },
       mask: "99/99",
       placeholder: dateFormat,
       type: 'text',

--- a/src/MonthPickerInput.tsx
+++ b/src/MonthPickerInput.tsx
@@ -24,7 +24,9 @@ export interface IProps {
     id?: string,
   },
   onChange?: OnChange,
-  closeOnSelect?: boolean
+  closeOnSelect?: boolean,
+  onChangeYearUpdate?: boolean,
+  inputRef?: Function
 };
 
 export interface IState {
@@ -106,6 +108,7 @@ class MonthPickerInput extends Component<IProps, IState> {
   };
 
   calendar = (): JSX.Element => {
+    const { onChangeYearUpdate } = this.props
     const { year, month } = this.state;
     let lang = this.props.lang ? this.props.lang : 'default';
     return (
@@ -116,18 +119,20 @@ class MonthPickerInput extends Component<IProps, IState> {
           lang={lang}
           onChange={this.onCalendarChange}
           onOutsideClick={this.onCalendarOutsideClick}
+          onChangeYearUpdate={onChangeYearUpdate}
         />
       </div>
     )
   };
 
   inputProps = (): object => {
+    const { inputRef } = this.props
     let dateFormat = DATE_FORMAT["default"];
     if (this.props.lang == "ja") {
       dateFormat = DATE_FORMAT["ja"];
     }
     return Object.assign({}, {
-      ref: input => { if(input) this.input = input; },
+      ref: inputRef ? inputRef : (input) => { if(input) this.input = input; },
       mask: "99/99",
       placeholder: dateFormat,
       type: 'text',

--- a/src/calendar/MonthCalendar.tsx
+++ b/src/calendar/MonthCalendar.tsx
@@ -12,6 +12,7 @@ export interface IProps {
   startYear?: number,
   onChange: (selectedYear: number, selectedMonth: number) => any,
   onOutsideClick: (e: any) => any,
+  onChangeYearUpdate?: boolean
 }
 
 export interface IState {
@@ -24,6 +25,10 @@ export interface IState {
 }
 
 class MonthCalendar extends Component<IProps, IState> {
+  static defaultProps = {
+    onChangeYearUpdate: true
+  }
+
   constructor(props: IProps){
     super(props);
 
@@ -48,8 +53,9 @@ class MonthCalendar extends Component<IProps, IState> {
   }
 
   selectYear = (selectedYear: number): void => {
+    const { onChangeYearUpdate } = this.props
     this.setState({ selectedYear, currentView: VIEW_MONTHS });
-    this.onChange(selectedYear, this.state.selectedMonth);
+    onChangeYearUpdate && this.onChange(selectedYear, this.state.selectedMonth);
   };
 
   selectMonth = (selectedMonth: number): void => {
@@ -143,12 +149,12 @@ class MonthCalendar extends Component<IProps, IState> {
   }
 
   componentWillReceiveProps(nextProps) {
+    const { year: oldYear, month: oldMonth } = this.props
     const { year, month } = nextProps;
-    const { selectedYear, selectedMonth } = this.state;
 
     if (typeof year == 'number' &&
       typeof month == 'number' &&
-      (year !== selectedYear || month !== selectedMonth)
+      (year !== oldYear || month !== oldMonth)
     ) {
       this.setState({
         selectedYear: year,


### PR DESCRIPTION
- Add `onChangeYearUpdate` props that will accept boolean value(default: `TRUE`). This will **disable** auto trigger of onChange to clicking `previous` and `next` button. (This should be not the default behavior)

-Add Also `inputRef` props that will enable the user to create it's own reference to the input. This will create flexibility since user can manipulate the input base on it's need.
